### PR TITLE
Fix: Replace deprecated delim_whitespace with sep=r"\s+" for pandas >= 2.2

### DIFF
--- a/code/MixMHCpred.py
+++ b/code/MixMHCpred.py
@@ -187,7 +187,7 @@ def distance_to_training(lib_path,training_Alleles,predicted_Alleles):
 
     Allele_Pos_idx = get_Allele_index(f'{lib_path}/Allele_pos')
     # print(training_Alleles)
-    seq_data = pd.read_csv(f"{lib_path}/MHC_I_sequences.txt", delim_whitespace= True)
+    seq_data = pd.read_csv(f"{lib_path}/MHC_I_sequences.txt", sep=r"\s+")
     for x in training_Alleles:
         if x not in seq_data['Allele'].tolist():
             print(f'{x} Fuck')

--- a/code/main.py
+++ b/code/main.py
@@ -207,7 +207,7 @@ if len(Alleles_out)>0:
     
     from panPredictor import *
     
-    seq_data = pd.read_csv(f"{lib_path}/MHC_I_sequences.txt", delim_whitespace= True)
+    seq_data = pd.read_csv(f"{lib_path}/MHC_I_sequences.txt", sep=r"\s+")
     Alleles_ = seq_data['Allele'].tolist()
     # Alleles_seq = list(seq_data['Sequence'])
     # Alleles_H = Alleles_

--- a/code/main_sequences.py
+++ b/code/main_sequences.py
@@ -258,7 +258,7 @@ def distance_to_training_special(lib_path,training_Alleles,seq):
 
     Allele_Pos_idx = get_Allele_index(f'{lib_path}/Allele_pos')
     # print(training_Alleles)
-    seq_data = pd.read_csv(f"{lib_path}/MHC_I_sequences.txt", delim_whitespace= True)
+    seq_data = pd.read_csv(f"{lib_path}/MHC_I_sequences.txt", sep=r"\s+")
 
     Alleles_seq_training = [seq_data[seq_data['Allele']== allele]['Sequence'].iloc[0] for allele in training_Alleles]
 


### PR DESCRIPTION
## What

pandas >= 2.2 removed the `delim_whitespace` keyword argument from `pd.read_csv()`, causing a `TypeError` crash before any predictions can be made.

## Fix

Replace `delim_whitespace=True` with `sep=r"\s+"` which provides equivalent whitespace delimiting behavior.

## Files changed
- `code/main.py` line 210
- `code/main_sequences.py` line 261
- `code/MixMHCpred.py` line 190

## Testing

Tested locally with pandas 2.3.3 (the version mentioned in the issue).

Fixes #14